### PR TITLE
feat(desktop): visualize db status and indicators

### DIFF
--- a/code/Desktop/src/Desktop/Desktop.csproj
+++ b/code/Desktop/src/Desktop/Desktop.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0"/>
+        <PackageReference Include="ScottPlot.Avalonia" Version="4.1.67" />
     </ItemGroup>
 
     <ItemGroup>

--- a/code/Desktop/src/Desktop/Views/MainWindow.axaml
+++ b/code/Desktop/src/Desktop/Views/MainWindow.axaml
@@ -1,20 +1,44 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="using:Desktop.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        xmlns:sp="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
+        mc:Ignorable="d"
         x:Class="Desktop.Views.MainWindow"
-        x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
-        Title="Desktop">
+        Title="InvestmentTools">
 
-    <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <vm:MainWindowViewModel/>
-    </Design.DataContext>
+    <Grid>
+        <Border Padding="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Spacing="16">
+                <TextBlock Name="StatusText"
+                           Text="Checking database connection..."
+                           FontSize="20"
+                           HorizontalAlignment="Center"/>
 
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <Button Name="AddIndicatorButton"
+                        Content="Add Test Indicator"
+                        Width="200"
+                        HorizontalAlignment="Center"/>
 
+                <TextBlock Name="IndicatorResultText"
+                           Text="No indicators loaded yet."
+                           TextAlignment="Center"/>
+
+                <Border BorderBrush="#DDDDDD"
+                        BorderThickness="1"
+                        Padding="8"
+                        MinWidth="480"
+                        MinHeight="260">
+                    <sp:AvaPlot Name="IndicatorPlot"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"/>
+                </Border>
+            </StackPanel>
+        </Border>
+    </Grid>
 </Window>

--- a/code/Desktop/src/Desktop/Views/MainWindow.axaml.cs
+++ b/code/Desktop/src/Desktop/Views/MainWindow.axaml.cs
@@ -1,28 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
-using Microsoft.Extensions.DependencyInjection;
+using Domain.Entity;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ScottPlot.Avalonia;
 
 namespace Desktop.Views;
 
 public partial class MainWindow : Window
 {
+    private readonly IServiceProvider serviceProvider;
+    private readonly TextBlock statusText;
+    private readonly TextBlock indicatorResultText;
+    private readonly AvaPlot indicatorPlot;
+    private readonly Button addIndicatorButton;
+
     public MainWindow()
     {
         InitializeComponent();
 
-        Opened += async (_, __) =>
+        if (Application.Current is not App app)
         {
-            var sp = ((App)Application.Current!).Services;
+            throw new InvalidOperationException("Unable to access application services.");
+        }
 
-            var factory = sp.GetRequiredService<IDbContextFactory<EntityFrameworkContext>>();
-            await using var db = await factory.CreateDbContextAsync();
+        serviceProvider = app.Services;
+        statusText = this.FindControl<TextBlock>("StatusText")
+                     ?? throw new InvalidOperationException("StatusText control not found.");
+        indicatorResultText = this.FindControl<TextBlock>("IndicatorResultText")
+                             ?? throw new InvalidOperationException("IndicatorResultText control not found.");
+        indicatorPlot = this.FindControl<AvaPlot>("IndicatorPlot")
+                       ?? throw new InvalidOperationException("IndicatorPlot control not found.");
+        addIndicatorButton = this.FindControl<Button>("AddIndicatorButton")
+                           ?? throw new InvalidOperationException("AddIndicatorButton control not found.");
 
-            var ok = await db.Database.CanConnectAsync();
-            Title = ok 
-                ? "InvestmentTools — DB: connected" 
-                : "InvestmentTools — DB: not reachable";
-        };
+        Opened += async (_, __) => await RefreshAsync();
+        addIndicatorButton.Click += async (_, __) => await AddTestIndicatorAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            await using var db = await CreateContextAsync();
+            var canConnect = await db.Database.CanConnectAsync();
+            UpdateConnectionStatus(canConnect);
+
+            if (!canConnect)
+            {
+                indicatorResultText.Text = "Database not reachable.";
+                ClearPlot("No data to display");
+                return;
+            }
+
+            await LoadIndicatorsAsync(db);
+        }
+        catch (Exception ex)
+        {
+            statusText.Text = "Error checking database";
+            Title = "InvestmentTools — DB: error";
+            indicatorResultText.Text = $"Unable to contact database: {ex.Message}";
+            ClearPlot("No data to display");
+        }
+    }
+
+    private async Task AddTestIndicatorAsync()
+    {
+        try
+        {
+            await using var db = await CreateContextAsync();
+            var canConnect = await db.Database.CanConnectAsync();
+
+            if (!canConnect)
+            {
+                UpdateConnectionStatus(false);
+                indicatorResultText.Text = "Cannot insert indicator because the database is not reachable.";
+                ClearPlot("No data to display");
+                return;
+            }
+
+            var indicator = new Indicator(Guid.NewGuid().ToString("N"),
+                $"Test Indicator {DateTime.UtcNow:HH:mm:ss}",
+                Random.Shared.Next(10, 101),
+                DateTime.UtcNow);
+
+            db.Indicators.Add(indicator);
+            await db.SaveChangesAsync();
+
+            indicatorResultText.Text = $"Inserted {indicator.Name} with value {indicator.Value}.";
+            await LoadIndicatorsAsync(db);
+        }
+        catch (Exception ex)
+        {
+            indicatorResultText.Text = $"Failed to insert indicator: {ex.Message}";
+        }
+    }
+
+    private async Task LoadIndicatorsAsync(EntityFrameworkContext db)
+    {
+        var indicators = await db.Indicators
+            .OrderBy(indicator => indicator.CreatedAt)
+            .ToListAsync();
+
+        if (indicators.Count == 0)
+        {
+            indicatorResultText.Text = "No indicators stored yet.";
+            ClearPlot("No indicator data");
+            return;
+        }
+
+        var latest = indicators[^1];
+        indicatorResultText.Text = $"Last indicator: {latest.Name} — Value {latest.Value} at {latest.CreatedAt:u}";
+
+        RenderBarChart(indicators);
+    }
+
+    private void RenderBarChart(IReadOnlyList<Indicator> indicators)
+    {
+        indicatorPlot.Plot.Clear();
+
+        var values = indicators.Select(indicator => (double)indicator.Value).ToArray();
+        var labels = indicators.Select(indicator => indicator.Name).ToArray();
+
+        indicatorPlot.Plot.AddBar(values);
+        indicatorPlot.Plot.XTicks(labels);
+        indicatorPlot.Plot.SetAxisLimits(yMin: 0);
+        indicatorPlot.Plot.Title("Indicator values");
+        indicatorPlot.Plot.YLabel("Value");
+        indicatorPlot.Plot.XLabel("Indicator");
+
+        indicatorPlot.Refresh();
+    }
+
+    private void UpdateConnectionStatus(bool canConnect)
+    {
+        statusText.Text = canConnect ? "Connected to Database" : "Database Not Reachable";
+        Title = $"InvestmentTools — DB: {(canConnect ? "connected" : "not reachable")}";
+    }
+
+    private void ClearPlot(string title)
+    {
+        indicatorPlot.Plot.Clear();
+        indicatorPlot.Plot.Title(title);
+        indicatorPlot.Refresh();
+    }
+
+    private async Task<EntityFrameworkContext> CreateContextAsync()
+    {
+        var factory = serviceProvider.GetRequiredService<IDbContextFactory<EntityFrameworkContext>>();
+        return await factory.CreateDbContextAsync();
     }
 }


### PR DESCRIPTION
## Summary
- replace the main window content with a status label, action button, indicator details, and a ScottPlot chart
- implement code-behind logic to verify the database connection, insert a test indicator, and refresh the displayed data
- reference the ScottPlot.Avalonia package to render a simple bar chart of indicator values

## Testing
- dotnet build "Investment Tools.sln" *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86d034f208324883cd16a7a8dff83