### PR TITLE
feat: add indicator persistence infrastructure

### DIFF
--- a/code/Domain/src/Repository/IIndicatorRepository.cs
+++ b/code/Domain/src/Repository/IIndicatorRepository.cs
@@ -1,0 +1,10 @@
+using Domain.Entity;
+
+namespace Domain.Repository;
+
+public interface IIndicatorRepository
+{
+    Task<Indicator?> GetByIdAsync(string indicatorId, CancellationToken cancellationToken);
+
+    Task AddAsync(Indicator indicator, CancellationToken cancellationToken);
+}

--- a/code/Infrastructure/src/Persistence/Configurations/IndicatorEntityTypeConfiguration.cs
+++ b/code/Infrastructure/src/Persistence/Configurations/IndicatorEntityTypeConfiguration.cs
@@ -1,0 +1,30 @@
+using Domain.Entity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+public sealed class IndicatorEntityTypeConfiguration : IEntityTypeConfiguration<Indicator>
+{
+    public void Configure(EntityTypeBuilder<Indicator> builder)
+    {
+        builder.ToTable("indicator");
+
+        builder.HasKey(indicator => indicator.IndicatorId);
+
+        builder.Property(indicator => indicator.IndicatorId)
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(indicator => indicator.Name)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(indicator => indicator.Value)
+            .IsRequired();
+
+        builder.Property(indicator => indicator.CreatedAt)
+            .HasColumnType("datetime(6)")
+            .IsRequired();
+    }
+}

--- a/code/Infrastructure/src/Persistence/EntityFrameworkContext.cs
+++ b/code/Infrastructure/src/Persistence/EntityFrameworkContext.cs
@@ -1,4 +1,5 @@
 using Domain.Entity;
+using Infrastructure.Persistence.Configurations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Persistence;
@@ -9,19 +10,11 @@ public sealed class EntityFrameworkContext(DbContextOptions<EntityFrameworkConte
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<Indicator>(eb =>
-        {
-            eb.ToTable("indicator");
+        modelBuilder.UseSnakeCaseNamingConvention();
+        modelBuilder.HasCharSet("utf8mb4");
 
-            eb.HasKey(i => i.IndicatorId);
-            eb.Property(i => i.IndicatorId).HasMaxLength(128).IsRequired();
+        modelBuilder.ApplyConfiguration(new IndicatorEntityTypeConfiguration());
 
-            eb.Property(i => i.Name).HasMaxLength(256).IsRequired();
-            eb.Property(i => i.Value).IsRequired();
-
-            eb.Property(i => i.CreatedAt)
-                .HasColumnType("datetime(6)")
-                .IsRequired();
-        });
+        base.OnModelCreating(modelBuilder);
     }
 }

--- a/code/Infrastructure/src/Persistence/EntityFrameworkContextFactory.cs
+++ b/code/Infrastructure/src/Persistence/EntityFrameworkContextFactory.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
+
+namespace Infrastructure.Persistence;
+
+public sealed class EntityFrameworkContextFactory : IDesignTimeDbContextFactory<EntityFrameworkContext>
+{
+    public EntityFrameworkContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<EntityFrameworkContext>();
+        var connectionString = "Server=localhost;Port=3306;Database=investment_tools;User Id=it_user;Password=it_password;";
+
+        optionsBuilder.UseMySql(
+            connectionString,
+            ServerVersion.Create(new Version(8, 0, 39), ServerType.MySql),
+            mysqlOptionsAction: builder =>
+                builder.MigrationsAssembly(typeof(EntityFrameworkContext).Assembly.GetName().Name));
+
+        return new EntityFrameworkContext(optionsBuilder.Options);
+    }
+}

--- a/code/Infrastructure/src/Persistence/Migrations/20241010120000_InitialIndicator.cs
+++ b/code/Infrastructure/src/Persistence/Migrations/20241010120000_InitialIndicator.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations;
+
+public partial class InitialIndicator : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterDatabase()
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.CreateTable(
+            name: "indicator",
+            columns: table => new
+            {
+                indicator_id = table.Column<string>(type: "varchar(128)", maxLength: 128, nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                name = table.Column<string>(type: "varchar(256)", maxLength: 256, nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                value = table.Column<int>(type: "int", nullable: false),
+                created_at = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator", x => x.indicator_id);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "indicator");
+    }
+}

--- a/code/Infrastructure/src/Persistence/Migrations/EntityFrameworkContextModelSnapshot.cs
+++ b/code/Infrastructure/src/Persistence/Migrations/EntityFrameworkContextModelSnapshot.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Persistence.Migrations;
+
+[DbContext(typeof(EntityFrameworkContext))]
+partial class EntityFrameworkContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+#pragma warning disable 612, 618
+        modelBuilder
+            .HasAnnotation("ProductVersion", "9.0.9")
+            .HasAnnotation("Relational:MaxIdentifierLength", 64)
+            .HasAnnotation("MySql:CharSet", "utf8mb4");
+
+        modelBuilder.HasCharSet("utf8mb4");
+
+        modelBuilder.Entity("Domain.Entity.Indicator", b =>
+        {
+            b.Property<string>("IndicatorId")
+                .HasMaxLength(128)
+                .HasColumnType("varchar(128)")
+                .HasColumnName("indicator_id")
+                .HasCharSet("utf8mb4");
+
+            b.Property<DateTime>("CreatedAt")
+                .HasColumnType("datetime(6)")
+                .HasColumnName("created_at");
+
+            b.Property<string>("Name")
+                .HasMaxLength(256)
+                .HasColumnType("varchar(256)")
+                .HasColumnName("name")
+                .HasCharSet("utf8mb4");
+
+            b.Property<int>("Value")
+                .HasColumnType("int")
+                .HasColumnName("value");
+
+            b.HasKey("IndicatorId");
+
+            b.ToTable("indicator")
+                .HasCharSet("utf8mb4");
+        });
+#pragma warning restore 612, 618
+    }
+}

--- a/code/Infrastructure/src/Persistence/Repositories/IndicatorRepository.cs
+++ b/code/Infrastructure/src/Persistence/Repositories/IndicatorRepository.cs
@@ -1,0 +1,27 @@
+using Domain.Entity;
+using Domain.Repository;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Persistence.Repositories;
+
+public sealed class IndicatorRepository(EntityFrameworkContext context) : IIndicatorRepository
+{
+    private readonly EntityFrameworkContext _context = context;
+
+    public async Task<Indicator?> GetByIdAsync(string indicatorId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(indicatorId);
+
+        return await _context.Indicators
+            .AsNoTracking()
+            .FirstOrDefaultAsync(indicator => indicator.IndicatorId == indicatorId, cancellationToken);
+    }
+
+    public async Task AddAsync(Indicator indicator, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(indicator);
+
+        await _context.Indicators.AddAsync(indicator, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add domain repository contract for indicators
- implement EF Core mapping, design-time factory, and repository for the Indicator aggregate
- include initial database migration for the indicator table

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb8fd55bd48324a5da066238a136c8